### PR TITLE
fix svg for safari browser

### DIFF
--- a/src/template/card.svg
+++ b/src/template/card.svg
@@ -18,11 +18,6 @@
     ry: 4px;
   }
 
-  foreignObject {
-    width: calc(100% - 1px - 32px);
-    height: calc(100% - 1px - 32px);
-  }
-
   table {
     width: 100%;
     border-collapse: collapse;
@@ -109,7 +104,7 @@
 <g>
   <rect x="0.5" y="0.5" id="background"/>
   <g>
-    <foreignObject x="17" y="17">
+    <foreignObject x="17" y="17" width="347" height="{{ height - 33 }}">
       <div xmlns="http://www.w3.org/1999/xhtml">
         <table>
           <thead>


### PR DESCRIPTION
`calc` is not very well supported in safari browsers

fixes #3 