### PR TITLE
Update cache action version from v2 to v3

### DIFF
--- a/.github/workflows/docs_publish.yml
+++ b/.github/workflows/docs_publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
failing workflow because of v2: https://github.com/RedHeadphone/codeforces-readme-stats/actions/runs/16386092274/job/46305788413